### PR TITLE
Fixed error where artists name was missing

### DIFF
--- a/front-end/src/pages/FavoriteArtists.js
+++ b/front-end/src/pages/FavoriteArtists.js
@@ -32,7 +32,7 @@ const FavoriteArtists = (props) => {
          },
          {
            id: 2,
-           title: "Mindy Wu",
+           name: "Mindy Wu",
          }
        ]
        setFavArtists(backupData)


### PR DESCRIPTION
There was an error with one of the artist objects in the backup data of the Favorite Artists page having the wrong property name. It was causing an error in the filter function. Should be all fixed now